### PR TITLE
refactor: Make `start_block_height` required. Add error logs instead of `.unwrap()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ aws-config = "0.6.0"
 aws-endpoint = "0.6.0"
 aws-sdk-s3 = "0.6.0"
 aws-smithy-http = "0.36.0"
+futures = "0.3.5"
+itertools = "^0.10.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "bd8a2de708b0350046eb16ce398a7ec896a94f0c" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "ea731e37efd2db44313a2769ad5b0e12ae9c3e34" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 rust-version = "1.58.1"
 
 [dependencies]
+anyhow = "1.0.51"
 aws-config = "0.6.0"
 aws-endpoint = "0.6.0"
 aws-sdk-s3 = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ pub fn streamer(config: LakeConfig) -> mpsc::Receiver<near_indexer_primitives::S
     let (sender, receiver) = mpsc::channel(100);
     tokio::spawn(start(
         sender,
-        config.bucket,
-        config.region,
+        config.s3_bucket_name,
+        config.s3_region_name,
         config.start_block_height,
     ));
     receiver

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ pub use types::LakeConfig;
 mod s3_fetchers;
 pub(crate) mod types;
 
-const LAKE_FRAMEWORK: &str = "near_lake_framework";
+pub(crate) const LAKE_FRAMEWORK: &str = "near_lake_framework";
 
 pub fn streamer(config: LakeConfig) -> mpsc::Receiver<near_indexer_primitives::StreamerMessage> {
-    let (sender, receiver) = mpsc::channel(16);
+    let (sender, receiver) = mpsc::channel(100);
     tokio::spawn(start(
         sender,
         config.bucket,
@@ -26,69 +26,65 @@ pub fn streamer(config: LakeConfig) -> mpsc::Receiver<near_indexer_primitives::S
 
 ///
 async fn start(
-    file_sink: mpsc::Sender<near_indexer_primitives::StreamerMessage>,
-    bucket: String,
-    region: String,
-    start_from_block_height: u64,
+    streamer_message_sink: mpsc::Sender<near_indexer_primitives::StreamerMessage>,
+    s3_bucket_name: String,
+    s3_region_name: String,
+    index_from_block_height: u64,
 ) {
     // instantiate AWS S3 Client
-    let region_provider = RegionProviderChain::first_try(Some(region).map(Region::new))
+    let region_provider = RegionProviderChain::first_try(Some(s3_region_name).map(Region::new))
         .or_default_provider()
         .or_else(Region::new("eu-central-1"));
     let shared_config = aws_config::from_env().region(region_provider).load().await;
-    let client = Client::new(&shared_config);
+    let s3_client = Client::new(&shared_config);
 
-    // `list_block` returns `continuation_token` which needs to be provided
-    // on the next call to get the next portion of objects (pagination)
-    let mut continuation_token: Option<String> = None;
+    let mut start_from_block_height: String = index_from_block_height.to_string();
 
-    // Continuously get the list of block data from S3 and send them to the `file_sink`
+    // Continuously get the list of block data from S3 and send them to the `streamer_message_sink`
     loop {
         // TODO: decide what to do if we got an error
-        if let Ok(list_object_response) = s3_fetchers::list_blocks(
-            &client,
-            &bucket,
-            Some(start_from_block_height.to_string()),
-            continuation_token.clone(),
-        )
-        .await
+        if let Ok(block_heights_prefixes) =
+            s3_fetchers::list_blocks(&s3_client, &s3_bucket_name, start_from_block_height.clone())
+                .await
         {
-            // update the token for the next iter (pagination)
-            continuation_token = list_object_response.continuation_token;
+            // update start_after key
+            start_from_block_height = {
+                if block_heights_prefixes.is_empty() {
+                    start_from_block_height
+                } else {
+                    block_heights_prefixes[block_heights_prefixes.len() - 1]
+                        .split('/')
+                        .collect::<Vec<&str>>()
+                        .get(0)
+                        .map(|s| (s.parse::<u64>().unwrap() + 1).to_string())
+                        .unwrap_or_else(|| start_from_block_height)
+                }
+            };
 
-            let mut blocks_futures: futures::stream::FuturesOrdered<_> = list_object_response
-                .folder_names
-                .iter()
-                .map(|folder| {
-                    build_and_send_streamer_message(&file_sink, &client, &bucket, &folder)
-                })
-                .collect();
+            let mut streamer_messages_futures: futures::stream::FuturesOrdered<_> =
+                block_heights_prefixes
+                    .iter()
+                    .map(|block_height_prefix| {
+                        s3_fetchers::fetch_streamer_message(
+                            &s3_client,
+                            &s3_bucket_name,
+                            block_height_prefix,
+                        )
+                    })
+                    .collect();
 
-            while let Some(_response) = blocks_futures.next().await {}
+            while let Some(streamer_message_result) = streamer_messages_futures.next().await {
+                streamer_message_sink
+                    .send(streamer_message_result.unwrap())
+                    .await
+                    .unwrap();
+            }
         } else {
             tracing::error!(
                 target: LAKE_FRAMEWORK,
                 "Failed to list objects from bucket {}. Retrying...",
-                &bucket
+                &s3_bucket_name
             );
         }
-    }
-}
-
-/// Fetches the necessary data to build up the `StreamerMessage`
-/// and send it to the stream (`file_sink`)
-async fn build_and_send_streamer_message(
-    file_sink: &mpsc::Sender<near_indexer_primitives::StreamerMessage>,
-    client: &Client,
-    bucket: &str,
-    folder: &str,
-) {
-    let streamer_message_json = s3_fetchers::get_object(&client, &bucket, &folder)
-        .await
-        .unwrap();
-    if let Ok(streamer_message) =
-        serde_json::from_value::<near_indexer_primitives::StreamerMessage>(streamer_message_json)
-    {
-        file_sink.send(streamer_message).await.unwrap();
     }
 }

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -1,55 +1,48 @@
-use aws_sdk_s3::{Client, Error};
+use aws_sdk_s3::Client;
+use futures::stream::StreamExt;
 
 /// Queries the list of the objects in the bucket, grouped by "/" delimiter.
 /// Returns the continuation token along with the so called list of folder names
 /// that represent a block heights
 pub(crate) async fn list_blocks(
-    client: &Client,
-    bucket: &str,
-    start_after_block_height: Option<String>,
-    continuation_token: Option<String>,
-) -> Result<crate::types::ListObjectResponse, Error> {
-    let response = client
+    s3_client: &Client,
+    s3_bucket_name: &str,
+    start_from_block_height: String,
+) -> anyhow::Result<Vec<String>> {
+    let response = s3_client
         .list_objects_v2()
         .max_keys(1000)
         .delimiter("/".to_string())
-        .set_start_after(start_after_block_height)
-        .set_continuation_token(continuation_token)
-        .bucket(bucket)
+        .start_after(start_from_block_height)
+        .bucket(s3_bucket_name)
         .send()
         .await?;
 
-    let continuation_token = response.next_continuation_token().map(ToOwned::to_owned);
-    let folder_names = match response.common_prefixes() {
+    Ok(match response.common_prefixes() {
         None => vec![],
         Some(common_prefixes) => common_prefixes
-            .into_iter()
+            .iter()
             .filter_map(|common_prefix| common_prefix.prefix.clone())
             .collect(),
-    };
-
-    Ok(crate::types::ListObjectResponse {
-        continuation_token,
-        folder_names,
     })
 }
 
-/// By the given block height (`key`) gets the objects:
+/// By the given block height (`block_height_prefix`) gets the objects:
 /// - block.json
 /// - shard_N.json
 /// Reads the content of the objects and parses it to JSON.
 /// Returns the result in a single JSON
-pub(crate) async fn get_object(
-    client: &Client,
-    bucket: &str,
-    key: &str,
-) -> Result<serde_json::Value, Error> {
+pub(crate) async fn fetch_streamer_message(
+    s3_client: &Client,
+    s3_bucket_name: &str,
+    block_height_prefix: &str,
+) -> anyhow::Result<near_indexer_primitives::StreamerMessage> {
     let mut main_json = serde_json::json!({});
     let block_json: serde_json::Value = {
-        let response = client
+        let response = s3_client
             .get_object()
-            .bucket(bucket)
-            .key(format!("{}block.json", key))
+            .bucket(s3_bucket_name)
+            .key(format!("{}block.json", block_height_prefix))
             .send()
             .await?;
 
@@ -64,20 +57,40 @@ pub(crate) async fn get_object(
 
     let mut shards: Vec<serde_json::Value> = vec![];
 
-    for shard_id in 0..shards_num {
-        let response = client
-            .get_object()
-            .bucket(bucket)
-            .key(format!("{}shard_{}.json", key, shard_id))
-            .send()
-            .await?;
+    let mut shards_futures: futures::stream::FuturesOrdered<_> = (0..shards_num)
+        .collect::<Vec<u64>>()
+        .into_iter()
+        .map(|shard_id| {
+            fetch_shard_or_retry(s3_client, s3_bucket_name, block_height_prefix, shard_id)
+        })
+        .collect();
 
-        let body_bytes = response.body.collect().await.unwrap().into_bytes();
-
-        shards.push(serde_json::from_slice(body_bytes.as_ref()).unwrap());
+    while let Some(shard) = shards_futures.next().await {
+        shards.push(shard.unwrap());
     }
 
     main_json["shards"] = serde_json::Value::Array(shards);
 
-    Ok(main_json)
+    Ok(serde_json::from_value::<near_indexer_primitives::StreamerMessage>(main_json).unwrap())
+}
+
+async fn fetch_shard_or_retry(
+    s3_client: &Client,
+    s3_bucket_name: &str,
+    block_height_prefix: &str,
+    shard_id: u64,
+) -> anyhow::Result<serde_json::Value> {
+    loop {
+        if let Ok(response) = s3_client
+            .get_object()
+            .bucket(s3_bucket_name)
+            .key(format!("{}shard_{}.json", block_height_prefix, shard_id))
+            .send()
+            .await
+        {
+            let body_bytes = response.body.collect().await.unwrap().into_bytes();
+
+            break Ok(serde_json::from_slice(body_bytes.as_ref()).unwrap());
+        };
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,8 +6,6 @@ pub struct LakeConfig {
     pub region: String,
     /// Defines the block height to start indexing from
     pub start_block_height: u64,
-    /// List of shard indexes to track, pass empty Vec if you want to track all shards
-    pub tracked_shards: Vec<u8>,
 }
 
 pub(crate) struct ListObjectResponse {

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,8 +7,3 @@ pub struct LakeConfig {
     /// Defines the block height to start indexing from
     pub start_block_height: u64,
 }
-
-pub(crate) struct ListObjectResponse {
-    pub continuation_token: Option<String>,
-    pub folder_names: Vec<String>,
-}

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,8 +4,8 @@ pub struct LakeConfig {
     pub bucket: String,
     /// Region name
     pub region: String,
-    /// Defines the block height to start indexing from. Latest available if skipped
-    pub start_block_height: Option<u64>,
+    /// Defines the block height to start indexing from
+    pub start_block_height: u64,
     /// List of shard indexes to track, pass empty Vec if you want to track all shards
     pub tracked_shards: Vec<u8>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,9 @@
 /// Configuration struct for NEAR Lake Framework
 pub struct LakeConfig {
-    /// Bucket name
-    pub bucket: String,
-    /// Region name
-    pub region: String,
+    /// AWS S3 Bucket name
+    pub s3_bucket_name: String,
+    /// AWS S3 Region name for the provided Bucket
+    pub s3_region_name: String,
     /// Defines the block height to start indexing from
     pub start_block_height: u64,
 }


### PR DESCRIPTION
* `start_block_height` is required on the NEAR Lake Framework side, according to the decision made in #3 
* Increase the number of keys retrieved from S3 to 1000
* Improve performance around awaiting by introducing `FuturesOrdered`

Also, I've added error logs instead of some `.unwrap()`s but I haven't come up with the answer to what do we want to do in case of that errors.