### PR TITLE
refactor: Add leading zeros. Avoid returning the same block over and over again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "ea731e37efd2db44313a2769ad5b0e12ae9c3e34" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "5f09a3bf042b32d1ff26554433ad6449199ea02a" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ async fn start(
         {
             // update start_after key
             if let Some(last_block_height) = block_heights_prefixes.last() {
-                start_from_block_height = *last_block_height;
+                start_from_block_height = *last_block_height + 1;
             } else {
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                 continue;

--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -12,7 +12,7 @@ pub(crate) async fn list_blocks(
         .list_objects_v2()
         .max_keys(1000)
         .delimiter("/".to_string())
-        .start_after(start_from_block_height.to_string())
+        .start_after(format!("{:0>12}", start_from_block_height))
         .bucket(s3_bucket_name)
         .send()
         .await?;
@@ -50,7 +50,7 @@ pub(crate) async fn fetch_streamer_message(
             if let Ok(response) = s3_client
                 .get_object()
                 .bucket(s3_bucket_name)
-                .key(format!("{}/block.json", block_height))
+                .key(format!("{:0>12}/block.json", block_height))
                 .send()
                 .await
             {
@@ -89,7 +89,7 @@ async fn fetch_shard_or_retry(
         if let Ok(response) = s3_client
             .get_object()
             .bucket(s3_bucket_name)
-            .key(format!("{}/shard_{}.json", block_height, shard_id))
+            .key(format!("{:0>12}/shard_{}.json", block_height, shard_id))
             .send()
             .await
         {


### PR DESCRIPTION
* We had a bug that will return the last available block over and over again until the new one appears on S3 - fixed
* On NEAR Lake we have changed the naming convention to handle string sorting properly https://github.com/near/near-lake/pull/24. Addressed this on the framework side as well