### PR TITLE
feat: Ensure prev_hash matches the previously processed block for data consistency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,11 @@ async fn start(
                     // block (ensure we don't miss anything from S3)
                     // retrieve the data from S3 if prev_hashes don't match and repeat the main loop step
                     if prev_block_hash != streamer_message.block.header.prev_hash {
+                        tracing::warn!(
+                            target: LAKE_FRAMEWORK,
+                            "`prev_hash` does not match, refetching the data from S3 in 200ms",
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                         break;
                     }
                 }


### PR DESCRIPTION
In order to ensure we process data from S3 consistently and don't allow any possible "gaps" (e.g. having a few NEAR Lake nodes where one is storing fresher block while another still saving one of the previous), we compare the last processed block hash with `prev_hash` from the current block