### PR TITLE
Add option for custom s3 endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ aws-endpoint = "0.6.0"
 aws-sdk-s3 = "0.6.0"
 aws-smithy-http = "0.36.0"
 futures = "0.3.5"
+http = "0.2"
 itertools = "^0.10.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ async fn handle_streamer_message(
 
 ## How to use
 
+## Custom S3 storage
+
+In case you want to run you own near-lake instance and store data in some S3 compatible storage ([Minio](https://min.io/) or [Localstack](https://localstack.cloud/) as example)
+You can owerride default S3 API endpoint by using `s3_endpoint` option
+
+- run minio
+
+```bash
+$ mkdir -p /data/near-lake-custom && minio server /data
+```
+
+- add `s3_endpoint` parameter to LakeConfig instance
+
+```bash
+let config = LakeConfig {
+    s3_endpoint: "http://0.0.0.0:9000".to_string(), // AWS S3 custom API endpoint
+    s3_bucket_name: "near-lake-custom".to_string(), // AWS S3 bucket name
+    s3_region_name: "eu-central-1".to_string(), // AWS S3 bucket region
+    start_block_height: 1, // the latest block height
+};
+```
+
 ### AWS S3 Credentials
 
 In order to be able to get objects from the AWS S3 bucket you need to provide the AWS credentials.
@@ -85,6 +107,7 @@ Everything should be configured before the start of your indexer application via
 
 Available parameters:
 
+* `s3_endpoint: String` - provide the AWS S3 custom API ednpoint
 * `s3_bucket_name: String` - provide the AWS S3 bucket name (`near-lake-testnet`, `near-lake-mainnet` or yours if you run your own NEAR Lake)
 * `s3_region_name: String` - provide the region for AWS S3 bucket
 * `start_block_height: u64` - block height to start the stream from

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ async fn handle_streamer_message(
 
 ## Custom S3 storage
 
-In case you want to run you own near-lake instance and store data in some S3 compatible storage ([Minio](https://min.io/) or [Localstack](https://localstack.cloud/) as example)
+In case you want to run your own [near-lake](https://github.com/near/near-lake) instance and store data in some S3 compatible storage ([Minio](https://min.io/) or [Localstack](https://localstack.cloud/) as example)
 You can owerride default S3 API endpoint by using `s3_endpoint` option
 
 - run minio

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,7 @@ async fn start(
     let mut s3_conf = aws_sdk_s3::config::Builder::from(&shared_config);
     // Owerride S3 endpoint in case you want to use custom solution
     // like Minio or Localstack as a S3 compatible storage
-    if s3_endpoint.is_some() {
-        let endpoint = s3_endpoint.as_ref().unwrap();
+    if let Some(endpoint) = s3_endpoint {
         s3_conf = s3_conf.endpoint_resolver(Endpoint::immutable(endpoint.parse::<Uri>().unwrap()));
         tracing::info!(
             target: LAKE_FRAMEWORK,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Region, Endpoint};
+use aws_sdk_s3::{Client, Endpoint, Region};
 
 use futures::stream::StreamExt;
 use http::Uri;

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,8 @@ pub type BlockHeight = u64;
 
 /// Configuration struct for NEAR Lake Framework
 pub struct LakeConfig {
+	/// AWS S3 Custom Endpoint
+    pub s3_endpoint: Option<String>,
     /// AWS S3 Bucket name
     pub s3_bucket_name: String,
     /// AWS S3 Region name for the provided Bucket

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ pub type BlockHeight = u64;
 
 /// Configuration struct for NEAR Lake Framework
 pub struct LakeConfig {
-	/// AWS S3 Custom Endpoint
+    /// AWS S3 Custom Endpoint
     pub s3_endpoint: Option<String>,
     /// AWS S3 Bucket name
     pub s3_bucket_name: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ pub type BlockHeight = u64;
 
 /// Configuration struct for NEAR Lake Framework
 pub struct LakeConfig {
-    /// AWS S3 Custom Endpoint
+    /// AWS S3 compatible custom endpoint
     pub s3_endpoint: Option<String>,
     /// AWS S3 Bucket name
     pub s3_bucket_name: String,


### PR DESCRIPTION
Additionally for custom S3 endpoint into Near Lake Indexer https://github.com/near/near-lake/pull/29
It world be great to have the same feature for near-lake-framefork. That allow users to setup fully cloud agnostic environment through Localstack or Minio S3 compatible server.