### PR TITLE
refactor: Fetch shard_N.json based on block.chunks.len

### DIFF
--- a/src/s3_fetchers.rs
+++ b/src/s3_fetchers.rs
@@ -79,7 +79,7 @@ pub(crate) async fn fetch_streamer_message(
             .unwrap()
     };
 
-    let shards: Vec<near_indexer_primitives::IndexerShard> = (0..block_view.header.chunks_included)
+    let shards: Vec<near_indexer_primitives::IndexerShard> = (0..block_view.chunks.len() as u64)
         .collect::<Vec<u64>>()
         .into_iter()
         .map(|shard_id| fetch_shard_or_retry(s3_client, s3_bucket_name, block_height, shard_id))


### PR DESCRIPTION
This resolves #18 

A little bit of a context:

On the NEAR Lake side, we're storing the `shard_N.json` file even if the Block misses a Chunk. But we had an issue where `StateChanges` were a part of a Block not a Chunk in the early blocks. Now, this issue is fixed, and no **new** `StateChanges` appear in a Block itself. 

We decided that it's better to receive an empty `IndexerShard` in the stream than miss `StateChanges`. 