### PR TITLE
An improvement to S3 error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,10 +317,11 @@ async fn start(
             Err(err) => {
                 tracing::error!(
                     target: LAKE_FRAMEWORK,
-                    "Failed to list objects from bucket {}: {}. Retrying...",
+                    "Failed to list objects from bucket {}: {}. Retrying in 1s...",
                     &config.s3_bucket_name,
                     err,
                 );
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
         }
     }


### PR DESCRIPTION
If there are any S3 errors, such as invalid credentials, the framework currently results in a tight loop printing error messages that do not provide the actual error. This pull request adds the underlying S3 error to the output, and adds a 1s sleep to prevent a tight loop in this scenario.

Before:
```
May 10 16:13:16.754 DEBUG near_lake_framework: Fetching blocks from S3, after 87868917...
May 10 16:13:16.754 ERROR near_lake_framework: Failed to list objects from bucket near-lake-data-testnet. Retrying...
May 10 16:13:16.754 DEBUG near_lake_framework: Fetching blocks from S3, after 87868917...
May 10 16:13:16.754 ERROR near_lake_framework: Failed to list objects from bucket near-lake-data-testnet. Retrying...
May 10 16:13:16.754 DEBUG near_lake_framework: Fetching blocks from S3, after 87868917...
May 10 16:13:16.754 ERROR near_lake_framework: Failed to list objects from bucket near-lake-data-testnet. Retrying...
... (tight loop) ...
```

After:
```
May 10 16:14:59.250 DEBUG near_lake_framework: Fetching blocks from S3, after 87868917...
May 10 16:14:59.252 ERROR near_lake_framework: Failed to list objects from bucket near-lake-data-testnet: failed to construct request: Failed to load credentials from the credentials provider: The credentials provider was not properly configured: ProfileFile provider could not be built: profile `default` was not defined: could not find source profile default referenced from the root profile. Retrying in 1s...
May 10 16:15:00.254 DEBUG near_lake_framework: Fetching blocks from S3, after 87868917...
May 10 16:15:00.255 ERROR near_lake_framework: Failed to list objects from bucket near-lake-data-testnet: failed to construct request: Failed to load credentials from the credentials provider: The credentials provider was not properly configured: ProfileFile provider could not be built: profile `default` was not defined: could not find source profile default referenced from the root profile. Retrying in 1s...
May 10 16:15:01.257 DEBUG near_lake_framework: Fetching blocks from S3, after 87868917...
May 10 16:15:01.259 ERROR near_lake_framework: Failed to list objects from bucket near-lake-data-testnet: failed to construct request: Failed to load credentials from the credentials provider: The credentials provider was not properly configured: ProfileFile provider could not be built: profile `default` was not defined: could not find source profile default referenced from the root profile. Retrying in 1s...
... (slower loop) ...
```
