### PR TITLE
Remove panics in streamer, allow stream to be stopped gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...HEAD)
 
+- Remove calls to `.unwrap()` and `.expect()` within the stream sender that
+  could panic. Instead, a `Result` is returned from the sender task.
+
+### Breaking change
+
+- The `streamer()` function now returns a tuple, with the first element being a
+  `JoinHandle<Result<(), Error>>` that you can use to gracefully capture any
+  errors that occurred within the sender task. If you don't care about errors,
+  you can easily adapt to this change by changing:
+  ```rust
+  let receiver = near_lake_framework::streamer(settings);
+  ```
+  to this instead:
+  ```rust
+  let (_, receiver) = near_lake_framework::streamer(settings);
+  ```
+
 ## [0.3.0](https://github.com/near/near-lake-framework/compare/v0.2.0...v0.3.0) - 2022-06-10
 
 - Introduce `LakeConfigBuilder` for creating configs

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ async fn main() -> Result<(), tokio::io::Error> {
        .expect("Failed to build LakeConfig");
 
    // instantiate the NEAR Lake Framework Stream
-   let stream = near_lake_framework::streamer(config);
+   let (_, stream) = near_lake_framework::streamer(config);
 
    // read the stream events and pass them to a handler function with
    // concurrency 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,17 +228,21 @@ pub(crate) const LAKE_FRAMEWORK: &str = "near_lake_framework";
 ///        .build()
 ///        .expect("Failed to build LakeConfig");
 ///
-///     let stream = near_lake_framework::streamer(config);
+///     let (_, stream) = near_lake_framework::streamer(config);
 ///
 ///     while let Some(streamer_message) = stream.recv().await {
 ///         eprintln!("{:#?}", streamer_message);
 ///     }
 /// # }
 /// ```
-pub fn streamer(config: LakeConfig) -> mpsc::Receiver<near_indexer_primitives::StreamerMessage> {
+pub fn streamer(
+    config: LakeConfig,
+) -> (
+    tokio::task::JoinHandle<Result<(), anyhow::Error>>,
+    mpsc::Receiver<near_indexer_primitives::StreamerMessage>,
+) {
     let (sender, receiver) = mpsc::channel(100);
-    tokio::spawn(start(sender, config));
-    receiver
+    (tokio::spawn(start(sender, config)), receiver)
 }
 
 async fn start(


### PR DESCRIPTION
This changes the error handling in the streamer to expose a way to handle errors that occur on the sender, instead of using `panic()`.

**Note: this is a breaking change to `streamer()`, to now return a tuple instead of a single value.**

Example of cleanly terminating the stream after reaching some maximum block height:
```rust
   // instantiate the NEAR Lake Framework Stream
   let (sender, stream) = near_lake_framework::streamer(config);

   // We will stop streaming after this block height
   let max_height = 1234567;

   // read the stream events and pass them to a handler function with
   // concurrency 1
   let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
       .take_while(|streamer_message| {
           let in_range = streamer_message.block.header.height <= max_height;
           async move { in_range }
       })
       .map(|streamer_message| handle_streamer_message(streamer_message))
       .buffer_unordered(1usize);

   while let Some(_handle_message) = handlers.next().await {}
   drop(handlers); // close the channel here

   // propagate result from the sender
   match sender.await {
       Ok(Ok(())) => Ok(()),
       Ok(Err(e)) => Err(e),
       Err(e) => Err(anyhow::Error::from(e)), // JoinError
   }
```
