### PR TITLE
fix: Bump version for `serde_json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ derive_builder = "0.11.2"
 futures = "0.3.5"
 itertools = "^0.10.3"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.55"
+serde_json = "1.0.75"
 tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"


### PR DESCRIPTION
Addresses #34 by requiring higher minimum version of `serde_json`