### PR TITLE
Change to tracing::warn instead of tracing::error for retryable errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ async fn start(
                 }
             }
             Err(err) => {
-                tracing::error!(
+                tracing::warn!(
                     target: LAKE_FRAMEWORK,
                     "Failed to list objects from bucket {}: {}. Retrying in 1s...",
                     &config.s3_bucket_name,


### PR DESCRIPTION
As I've been running an indexer using this framework, on occasion I've seen these errors in the logs. As far as I can tell, the framework recovers automatically after retrying (sometimes after _several_ retries in a row). Since it _does_ recover automatically, I propose changing these logs to `warn` instead of `error` ... reserving `error` only for situations that require  manual intervention; i.e. where data loss has occurred (if the framework detects a missing block, stops streaming altogether, etc.)
