### PR TITLE
feat: improved streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/near/near-lake-framework/compare/v0.4.1...HEAD)
 
+- Added the configuration option to control the size of the pool of
+  preloaded blocks `blocks_preload_pool_size` (100 remains to be the default)
+
+### Breaking change
+
+- Dropped the previously allowed way to instantiate LakeConfig by manually
+  initializing the public fields in favor of
+  [the builder pattern](https://docs.rs/near-lake-framework/0.4.1/near_lake_framework/struct.LakeConfigBuilder.html)
+
 ## [0.4.1](https://github.com/near/near-lake-framework/compare/v0.4.0...v0.4.1) - 2022-06-14
 
 - Bumped the minimum required version of `serde_json` to 1.0.75 to avoid

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,12 +20,12 @@ pub type BlockHeight = u64;
 pub struct LakeConfig {
     /// AWS S3 Bucket name
     #[builder(setter(into))]
-    pub s3_bucket_name: String,
+    pub(crate) s3_bucket_name: String,
     /// AWS S3 Region name
     #[builder(setter(into))]
-    pub s3_region_name: String,
+    pub(crate) s3_region_name: String,
     /// Defines the block height to start indexing from
-    pub start_block_height: u64,
+    pub(crate) start_block_height: u64,
     /// Custom aws_sdk_s3::config::Config
     /// ## Use-case: custom endpoint
     /// You might want to stream data from the custom S3-compatible source () . In order to do that you'd need to pass `aws_sdk_s3::config::Config` configured
@@ -51,7 +51,9 @@ pub struct LakeConfig {
     /// # }
     /// ```
     #[builder(setter(strip_option), default)]
-    pub s3_config: Option<aws_sdk_s3::config::Config>,
+    pub(crate) s3_config: Option<aws_sdk_s3::config::Config>,
+    #[builder(default = "100")]
+    pub(crate) blocks_preload_pool_size: usize,
 }
 
 impl LakeConfigBuilder {


### PR DESCRIPTION
This was inspired by https://github.com/near/near-lake-framework-js/pull/4, but so far in my testing I actually hit the network limit sooner than this streaming limitation when I am testing it on the server (it can reach 1000 bps but then stuck for 5-10 seconds waiting for some delayed response). This approach is still more tolerant to sudden delays and it appears to be working better for the account activity indexer (where there is some actual block processing happening). Ultimately, I saw 150-450 bps on the current master branch and 150-600 bps on this PR branch when the block processing is actually just a print statement.

This also should cut the AWS costs on re-indexing since we do fewer ListObjectV2 calls (previously we called it with the limit of 100 keys, which is only 20 blocks when it comes to the point where we have 4 shards, but now we call it with [100 * 2 * (1 + 4)] 1000 keys).

This also closes #32, though with the streaming improvements we can afford to list more block heights ahead of time (twice the size of the blocks preload pool multiplied by the number of files for each block (1 for block-header.json + N for shards)).